### PR TITLE
feat(openai): allow import documents to declare metadata for non-JWT tokens

### DIFF
--- a/backend/crates/providers/openai/src/credential/admin.rs
+++ b/backend/crates/providers/openai/src/credential/admin.rs
@@ -121,6 +121,7 @@ impl fmt::Debug for PreparedCodexAccountImport {
 struct ParsedCodexImportAccount {
     name: Option<String>,
     email: Option<String>,
+    metadata: CodexOAuthMetadata,
     authentication: ParsedCodexAuthentication,
 }
 
@@ -822,25 +823,32 @@ impl CodexCredentialAdminService {
                 )
                 .await?;
             // 与官方 `parse_chatgpt_jwt_claims` 一致：先读 ID token，缺失字段
-            // 再由 access token 补齐。解析失败不阻塞 token 入库。
+            // 再由 access token 补齐。任一 token 能解析出 JWT claims 时，账号
+            // 资料只来自 token，导入文档声明的字段不参与投影；两个 token 都
+            // 不是 JWT（如团队静态访问令牌）时，回退到文档声明的资料，避免
+            // 静态令牌账号因无身份信息而无法入库调度。
             let id_metadata = secret
                 .id_token
                 .as_ref()
-                .and_then(|token| parse_chatgpt_jwt_claims(token.expose_secret()).ok())
-                .unwrap_or_default();
+                .and_then(|token| parse_chatgpt_jwt_claims(token.expose_secret()).ok());
             let access_metadata =
-                parse_chatgpt_jwt_claims(secret.access_token.expose_secret()).unwrap_or_default();
-            let metadata = CodexOAuthMetadata {
-                email: id_metadata.email.or(access_metadata.email),
-                chatgpt_plan_type: id_metadata
-                    .chatgpt_plan_type
-                    .or(access_metadata.chatgpt_plan_type),
-                chatgpt_user_id: id_metadata
-                    .chatgpt_user_id
-                    .or(access_metadata.chatgpt_user_id),
-                chatgpt_account_id: id_metadata
-                    .chatgpt_account_id
-                    .or(access_metadata.chatgpt_account_id),
+                parse_chatgpt_jwt_claims(secret.access_token.expose_secret()).ok();
+            let metadata = if id_metadata.is_some() || access_metadata.is_some() {
+                let id = id_metadata.unwrap_or_default();
+                let access = access_metadata.unwrap_or_default();
+                CodexOAuthMetadata {
+                    email: id.email.or(access.email),
+                    chatgpt_plan_type: id.chatgpt_plan_type.or(access.chatgpt_plan_type),
+                    chatgpt_user_id: id.chatgpt_user_id.or(access.chatgpt_user_id),
+                    chatgpt_account_id: id.chatgpt_account_id.or(access.chatgpt_account_id),
+                }
+            } else {
+                CodexOAuthMetadata {
+                    email: candidate.email.clone(),
+                    chatgpt_plan_type: candidate.metadata.chatgpt_plan_type,
+                    chatgpt_user_id: candidate.metadata.chatgpt_user_id,
+                    chatgpt_account_id: candidate.metadata.chatgpt_account_id,
+                }
             };
             let prepared =
                 CodexCredentialAdmin.prepare_unresolved_oauth(UnresolvedCodexOAuthCredential {
@@ -1003,8 +1011,32 @@ fn parse_oauth_import_account(
     Ok(ParsedCodexImportAccount {
         name: first_string(value, &["name", "label"]),
         email: first_string(value, &["email"]).or_else(|| first_string(credentials, &["email"])),
+        metadata: parse_oauth_import_metadata(value, credentials),
         authentication: parse_oauth_import_tokens(value)?,
     })
+}
+
+/// 读取导入文档声明的账号资料，供非 JWT 形态的 access token（如团队静态
+/// 令牌）补全身份。仅在两个 token 都解析不出 JWT claims 时参与投影。
+fn parse_oauth_import_metadata(value: &Value, credentials: &Value) -> CodexOAuthMetadata {
+    let pick =
+        |keys: &[&str]| first_string(value, keys).or_else(|| first_string(credentials, keys));
+    CodexOAuthMetadata {
+        chatgpt_account_id: pick(&[
+            "chatgptAccountId",
+            "chatgpt_account_id",
+            "accountId",
+            "account_id",
+        ]),
+        chatgpt_user_id: pick(&["chatgptUserId", "chatgpt_user_id", "userId", "user_id"]),
+        chatgpt_plan_type: pick(&[
+            "chatgptPlanType",
+            "chatgpt_plan_type",
+            "planType",
+            "plan_type",
+        ]),
+        email: None,
+    }
 }
 
 fn import_account_values(payload: &Value) -> Result<Vec<&Value>, CodexCredentialAdminError> {

--- a/backend/crates/providers/openai/tests/credential/admin.rs
+++ b/backend/crates/providers/openai/tests/credential/admin.rs
@@ -237,7 +237,7 @@ async fn oauth_import_uses_id_token_then_access_token_for_missing_claims() {
 }
 
 #[tokio::test]
-async fn oauth_import_does_not_use_top_level_identity_fields() {
+async fn oauth_import_does_not_use_top_level_identity_fields_for_parseable_tokens() {
     let access_token = test_jwt(serde_json::json!({"exp": 2_000_000_000_i64}));
     let service = CodexCredentialAdminService::new(
         Arc::new(UnusedRefresher),
@@ -256,10 +256,87 @@ async fn oauth_import_does_not_use_top_level_identity_fields() {
         .expect("token without identity claims remains importable");
 
     let account = &prepared.accounts().first().expect("one account").account;
+    // token 可解析为 JWT 时，账号资料只来自 token claims，文档字段不参与
+    // 投影（文档 email 仍可用于命名回退）。
     assert!(account.upstream_user_id().is_none());
     assert!(account.upstream_account_id().is_none());
     assert!(account.email().is_none());
     assert!(account.plan_type().is_none());
+}
+
+#[tokio::test]
+async fn static_token_import_projects_document_metadata() {
+    // 团队静态访问令牌等非 JWT 形态的 opaque token 没有可解析的 claims，
+    // 账号资料回退到导入文档声明的元数据，导入后即可参与调度。
+    let service = CodexCredentialAdminService::new(
+        Arc::new(UnusedRefresher),
+        Arc::new(TestLeaseCoordinator::default()),
+        runtime_policy(),
+    );
+    let prepared = service
+        .prepare_import_document(serde_json::json!({
+            "platform": "openai",
+            "type": "oauth",
+            "name": "team-static-account",
+            "accessToken": "at-static-team-token",
+            "accountId": "28b90dfd-9abe-4875-94f5-5ed6bbf7b71e",
+            "userId": "user-static",
+            "planType": "team",
+            "email": "team@example.com"
+        }))
+        .await
+        .expect("opaque token with document metadata is accepted");
+
+    let prepared = prepared.accounts().first().expect("one account");
+    let account = &prepared.account;
+    assert_eq!(account.upstream_user_id(), Some("user-static"));
+    assert_eq!(
+        account.upstream_account_id(),
+        Some("28b90dfd-9abe-4875-94f5-5ed6bbf7b71e")
+    );
+    assert_eq!(account.plan_type(), Some("team"));
+    assert_eq!(account.email(), Some("team@example.com"));
+    assert_eq!(account.name(), "team-static-account");
+    assert_eq!(
+        account.credential_state(),
+        gateway_core::account::CredentialState::Ready
+    );
+    assert!(account.access_token_expires_at().is_none());
+    assert!(account.next_refresh_at().is_none());
+
+    let runtime = CodexCredentialCodec::decode(&prepared.credential).expect("stored credential");
+    let oauth = runtime.authentication.oauth().expect("OAuth credential");
+    assert_eq!(oauth.access_token.expose_secret(), "at-static-team-token");
+    assert!(oauth.refresh_token.is_none());
+}
+
+#[tokio::test]
+async fn static_token_import_reads_metadata_from_credentials_object() {
+    let service = CodexCredentialAdminService::new(
+        Arc::new(UnusedRefresher),
+        Arc::new(TestLeaseCoordinator::default()),
+        runtime_policy(),
+    );
+    let prepared = service
+        .prepare_import_document(serde_json::json!({
+            "platform": "openai",
+            "type": "oauth",
+            "credentials": {
+                "access_token": "at-another-static-token",
+                "account_id": "doc-account-from-credentials",
+                "plan_type": "team"
+            }
+        }))
+        .await
+        .expect("credentials-scoped metadata is accepted");
+
+    let account = &prepared.accounts().first().expect("one account").account;
+    assert_eq!(
+        account.upstream_account_id(),
+        Some("doc-account-from-credentials")
+    );
+    assert_eq!(account.plan_type(), Some("team"));
+    assert!(account.upstream_user_id().is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 背景

自托管网关常见一类 OpenAI Codex 账号：**团队（team/workspace）账号的静态访问令牌**——凭据形如 `at-...`（非 JWT、无 `refresh_token`），上游 `chatgpt.com/backend-api/codex` 直接接受它作为 Bearer 调用。这类凭据来自 CPA（CLIProxyAPI）等工具的导出格式，实际使用广泛。

当前 `prepare_import_document` 的身份投影只认 JWT claims，这类 opaque token 导入后会因解析不出 `chatgpt_user_id` 进入 `AccountUnverified`（credential state `Unknown`）状态，**永远不会被调度**。目前唯一的绕过办法是伪造一个携带 chatgpt claims 的 `id_token` JWT（解析路径不验签，可以骗过去）——这恰恰说明文档元数据的信任边界与 claims 解析是等价的，不如把这条路做成一等公民。

## 改动

`prepare_import_document` 在 **ID token 与 access token 都无法解析出 JWT claims** 时，账号资料回退到导入文档声明的元数据：

- 字段：`chatgptAccountId / accountId`、`chatgptUserId / userId`、`chatgptPlanType / planType`（顶层或 `credentials` 对象内均可，camelCase 与 snake_case 皆可）；`email` 沿用原有命名回退链并额外投影到账号资料
- **OAuth JWT 令牌的行为完全不变**：任一 token 能解析出 claims 时，账号资料仍然只来自 token claims，文档字段一律不参与投影（原有测试 `oauth_import_does_not_use_top_level_identity_fields` 语义原样保留，仅改名为 `..._for_parseable_tokens` 并补充注释）

## 示例

```json
{
  "accounts": [{
    "platform": "openai",
    "type": "codex",
    "name": "team-account",
    "access_token": "at-xxxx",
    "account_id": "28b90dfd-9abe-4875-94f5-5ed6bbf7b71e",
    "planType": "team",
    "email": "user@example.com"
  }]
}
```

导入后账号直接进入 Ready 状态参与调度，不再需要伪造 id_token。

## 测试

- 新增 `static_token_import_projects_document_metadata`：opaque token + 文档元数据 → 资料投影齐全、state Ready、无刷新计划
- 新增 `static_token_import_reads_metadata_from_credentials_object`：`credentials` 对象内的 snake_case 字段同样生效
- 改写 `oauth_import_does_not_use_top_level_identity_fields_for_parseable_tokens`：可解析 token 的文档字段忽略语义不变
- `cargo test -p provider-openai` 全部通过；`cargo fmt --check` 与 `cargo clippy` 干净