### PR TITLE
feat(config): allow opting into HTTP admin sessions

### DIFF
--- a/backend/apps/gateway/tests/bootstrap.rs
+++ b/backend/apps/gateway/tests/bootstrap.rs
@@ -160,6 +160,14 @@ fn config_loader_should_load_complete_terminal_example() {
 }
 
 #[test]
+fn config_loader_should_accept_opt_in_http_and_existing_configs_without_the_switch() {
+    for value in ["  allow_insecure_http: true\n", ""] {
+        let yaml = valid_config().replace("  allow_insecure_http: false\n", value);
+        parse_config(&yaml).expect("HTTP policy remains backward compatible");
+    }
+}
+
+#[test]
 fn config_loader_should_resolve_paths_relative_to_config_file() {
     let (config, _directory) = parse_config(&valid_config()).expect("resolved config");
     let debug = format!("{config:?}");

--- a/backend/crates/gateway-api/src/admin/auth.rs
+++ b/backend/crates/gateway-api/src/admin/auth.rs
@@ -20,11 +20,23 @@ use super::{AdminEnvelope, AdminError, AdminJson, AdminResponse};
 
 const REQUEST_ID_HEADER: &str = "x-request-id";
 const ADMIN_SESSION_COOKIE: &str = "cpr_admin_session";
-const ADMIN_SESSION_COOKIE_ATTRS: &str = "Path=/; Secure; HttpOnly; SameSite=Lax";
 
 /// 所有管理 HTTP 模块从 state 消费同一个认证用例端口。
 pub trait AdminSessionState {
     fn admin_services(&self) -> &AdminServices;
+
+    /// 仅部署配置可放宽会话 Cookie；不根据客户端的转发头自动降级。
+    fn allow_insecure_http(&self) -> bool {
+        false
+    }
+}
+
+fn admin_session_cookie_attrs(allow_insecure_http: bool) -> &'static str {
+    if allow_insecure_http {
+        "Path=/; HttpOnly; SameSite=Lax"
+    } else {
+        "Path=/; Secure; HttpOnly; SameSite=Lax"
+    }
 }
 
 /// 已通过管理员会话或部署级管理 API Key 鉴权的请求。
@@ -221,8 +233,9 @@ where
     )
     .into_response();
     let cookie = format!(
-        "{ADMIN_SESSION_COOKIE}={}; {ADMIN_SESSION_COOKIE_ATTRS}",
-        session.session_id
+        "{ADMIN_SESSION_COOKIE}={}; {}",
+        session.session_id,
+        admin_session_cookie_attrs(state.allow_insecure_http())
     );
     response.headers_mut().insert(
         SET_COOKIE,
@@ -260,7 +273,10 @@ where
     let mut response =
         AdminResponse::new(StatusCode::OK, AdminEnvelope::ok(AdminLogoutData::new()))
             .into_response();
-    let cookie = format!("{ADMIN_SESSION_COOKIE}=; {ADMIN_SESSION_COOKIE_ATTRS}; Max-Age=0");
+    let cookie = format!(
+        "{ADMIN_SESSION_COOKIE}=; {}; Max-Age=0",
+        admin_session_cookie_attrs(state.allow_insecure_http())
+    );
     response.headers_mut().insert(
         SET_COOKIE,
         HeaderValue::from_str(&cookie).map_err(|_| AdminError::internal())?,

--- a/backend/crates/gateway-api/src/lib.rs
+++ b/backend/crates/gateway-api/src/lib.rs
@@ -36,6 +36,9 @@ pub mod openai;
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct ApiConfig {
+    /// 显式允许管理员会话通过 HTTP 传输；默认仍签发 Secure Cookie。
+    #[serde(default)]
+    pub allow_insecure_http: bool,
     pub asset_directory: PathBuf,
     pub cors_allowed_origins: Vec<String>,
     pub request_timeout_seconds: Option<u64>,
@@ -127,6 +130,7 @@ pub fn initialize(
     let request_id_header = HeaderName::from_str(&config.request_id_header)
         .map_err(|_| ApiError::Config(ApiConfigError::InvalidRequestIdHeader))?;
     let state = ApiState {
+        allow_insecure_http: config.allow_insecure_http,
         admin,
         openai: OpenAiService::new(execution, lifecycle),
         health: HealthStatus::new(probes, worker_health),
@@ -208,6 +212,7 @@ pub enum ApiError {
 
 #[derive(Clone)]
 pub(crate) struct ApiState {
+    allow_insecure_http: bool,
     admin: AdminServices,
     openai: OpenAiService,
     health: HealthStatus,
@@ -228,6 +233,10 @@ impl ApiState {
 impl admin::AdminSessionState for ApiState {
     fn admin_services(&self) -> &AdminServices {
         &self.admin
+    }
+
+    fn allow_insecure_http(&self) -> bool {
+        self.allow_insecure_http
     }
 }
 

--- a/backend/crates/gateway-api/tests/openai/mod.rs
+++ b/backend/crates/gateway-api/tests/openai/mod.rs
@@ -73,14 +73,28 @@ async fn api_router_with_origins_and_worker_health(
     cors_allowed_origins: Vec<String>,
     worker_health: Arc<dyn WorkerHealthSource>,
 ) -> axum::Router {
-    let admin = crate::admin::AdminTestFixture::new().await;
-    gateway_api::initialize(
+    api_router_with_config(
+        execution,
         gateway_api::ApiConfig {
+            allow_insecure_http: false,
             asset_directory: std::env::temp_dir(),
             cors_allowed_origins,
             request_timeout_seconds: None,
             request_id_header: "x-request-id".to_owned(),
         },
+        worker_health,
+    )
+    .await
+}
+
+pub(crate) async fn api_router_with_config(
+    execution: Arc<dyn ExecutionService>,
+    config: gateway_api::ApiConfig,
+    worker_health: Arc<dyn WorkerHealthSource>,
+) -> axum::Router {
+    let admin = crate::admin::AdminTestFixture::new().await;
+    gateway_api::initialize(
+        config,
         execution,
         admin.services,
         Vec::new(),

--- a/backend/crates/gateway-api/tests/openai/responses/websocket/mod.rs
+++ b/backend/crates/gateway-api/tests/openai/responses/websocket/mod.rs
@@ -1116,6 +1116,7 @@ async fn websocket_disconnect_during_core_settlement_finishes_charge_before_rele
     let admin = crate::admin::AdminTestFixture::new().await;
     let app = gateway_api::initialize(
         gateway_api::ApiConfig {
+            allow_insecure_http: false,
             asset_directory: std::env::temp_dir(),
             cors_allowed_origins: Vec::new(),
             request_timeout_seconds: None,

--- a/backend/crates/gateway-api/tests/openai/router.rs
+++ b/backend/crates/gateway-api/tests/openai/router.rs
@@ -10,6 +10,96 @@ use super::models::ModelsExecution;
 const REMOVED_BODY_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 
 #[tokio::test]
+async fn configured_http_admin_sessions_preserve_login_status_and_logout() {
+    use axum::body::to_bytes;
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+
+    for setting in [None, Some(false), Some(true)] {
+        let mut config = json!({"asset_directory": std::env::temp_dir(),
+            "cors_allowed_origins": [], "request_timeout_seconds": null,
+            "request_id_header": "x-request-id"});
+        if let Some(value) = setting {
+            config["allow_insecure_http"] = json!(value);
+        }
+        let app = super::api_router_with_config(
+            ModelsExecution::new(),
+            serde_json::from_value(config).unwrap(),
+            Arc::new(super::EmptyWorkerHealth),
+        )
+        .await;
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/api/admin/auth/login")
+                    .header("content-type", "application/json")
+                    .header("x-forwarded-proto", "http")
+                    .body(Body::from(
+                        json!({"username": "admin_1", "password": "strong-admin-password"})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let cookie = response.headers()["set-cookie"].to_str().unwrap();
+        let session = cookie.split(';').next().unwrap().to_owned();
+        let attrs: Vec<_> = cookie.split(';').map(str::trim).collect();
+        assert_eq!(attrs.contains(&"Secure"), setting != Some(true));
+        for attribute in ["Path=/", "HttpOnly", "SameSite=Lax"] {
+            assert!(attrs.contains(&attribute));
+        }
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get("/api/admin/auth/status")
+                    .header("cookie", &session)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body: Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), 4096).await.unwrap()).unwrap();
+        assert_eq!(body["data"]["authenticated"], true);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/api/admin/auth/logout")
+                    .header("cookie", &session)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let cookie = response.headers()["set-cookie"].to_str().unwrap();
+        assert!(cookie.starts_with("cpr_admin_session=;"));
+        let attrs: Vec<_> = cookie.split(';').map(str::trim).collect();
+        assert_eq!(attrs.contains(&"Secure"), setting != Some(true));
+        for attribute in ["Path=/", "HttpOnly", "SameSite=Lax", "Max-Age=0"] {
+            assert!(attrs.contains(&attribute));
+        }
+
+        let response = app
+            .oneshot(
+                Request::get("/api/admin/auth/status")
+                    .header("cookie", &session)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body: Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), 4096).await.unwrap()).unwrap();
+        assert_eq!(body["data"]["authenticated"], false);
+    }
+}
+
+#[tokio::test]
 async fn removed_responses_review_route_should_not_reach_the_responses_handler() {
     let response = api_router_with_origins(ModelsExecution::new(), Vec::new())
         .await

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -78,12 +78,35 @@ PostgreSQL/Redis 启动密码。日常校验使用 `config --quiet`。
 
 ## 公网访问
 
-Compose 默认只绑定 `127.0.0.1`。从其他设备访问时，在应用前配置 HTTPS 反向代理，
+Compose 默认只绑定 `127.0.0.1`。从其他设备访问时，在应用前配置反向代理，
 不要把 PostgreSQL 或 Redis 暴露到公网。
+
+管理员会话默认使用 `Secure` Cookie，适用于浏览器通过 HTTPS 访问的部署。
+若需要通过 HTTP 登录，在现有 `deploy/config.yaml` 的 `api` 段添加：
+
+```yaml
+api:
+  allow_insecure_http: true
+```
+
+保留该段已有的其他字段。默认值为 `false`，旧配置省略此项时行为不变。开启后，登录及退出的
+会话 Cookie 不再携带 `Secure`，仍保留 `HttpOnly`、`SameSite=Lax` 和退出时的过期设置。
+HTTP 传输不加密，请由部署者按访问环境自行选择；此项不影响上游 TLS 证书验证。
+HTTPS 反向代理即使使用 HTTP 连接容器，也应保持默认值，开关取决于浏览器访问的协议。
+
+配置在启动时读取。升级到包含此功能的镜像后，重新创建应用容器以加载修改后的配置文件：
+
+```bash
+docker compose -f deploy/compose.yaml up -d --no-deps --force-recreate codex-proxy-rs
+```
+
+无需调整 Compose 的配置挂载，也无需 Nginx 重写 Cookie。若此前配置了移除或强加 `Secure` 的
+Cookie 重写规则，应移除该规则，使应用开关生效。直接暴露应用端口时，可将应用的端口映射改为
+`0.0.0.0:8080:8080`；数据库和 Redis 的端口保持仅本机访问。
 
 反向代理需要保留 `Authorization`，支持 `/v1/responses` 的 WebSocket Upgrade，
 并关闭 SSE 响应缓冲。读取超时应覆盖长时间生成任务。
-客户端使用 `https://你的域名/v1`，不要使用前端开发服务的 `5173/dev/v1`。
+客户端使用部署地址下的 `/v1`，协议与部署一致，不要使用前端开发服务的 `5173/dev/v1`。
 当前应用只支持单副本，不能通过复制容器扩容。
 
 流式响应在首个上游事件提交后，每 15 秒无输出会发送一次 SSE 注释保活，

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -55,6 +55,8 @@ admin:
   default_password: ''
 
 api:
+  # 允许 HTTP 管理员登录；开启后会话 Cookie 不带 Secure。默认关闭。
+  allow_insecure_http: false
   # Docker 内由 CPR_WEB_DIST_DIR 覆盖。
   asset_directory: '../frontend/dist'
   cors_allowed_origins: []

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,6 +51,11 @@ Client Key 通过账号分组限定路由范围：未绑定分组时可使用全
 - 浏览器登录后得到的 `cpr_admin_session` Cookie；
 - `x-api-key: <admin-api-key>`。
 
+管理员登录和退出默认签发带 `Secure`、`HttpOnly`、`SameSite=Lax` 的 Cookie。
+部署配置 `api.allow_insecure_http: true` 会仅移除 `Secure`，允许浏览器通过 HTTP 保存会话；
+省略或设为 `false` 保持默认行为，不根据 `X-Forwarded-Proto` 等请求头自动降级。
+配置和重启步骤见 [公网访问](../deploy/README.md#公网访问)。
+
 请求无需自带 `x-request-id`；缺失时服务端自动生成 UUID 并在响应头回传同一 request ID。
 `api.request_id_header` 可改变注入与回传的 header 名，管理端鉴权不依赖该名字。
 管理端响应统一带 `Cache-Control: no-store`。


### PR DESCRIPTION
## 中文

通过普通 HTTP 部署管理端时，用户名和密码验证成功，但浏览器无法保存带 `Secure` 的会话 Cookie，后续请求仍显示未登录。v3.5.0 / `14e7967` 在 [admin/auth.rs](https://github.com/zyycn/codex-proxy-rs/blob/14e7967e1cd17eed36aa2a5b7d317fb32c8cde37/backend/crates/gateway-api/src/admin/auth.rs) 中固定为登录和退出设置 `Secure`；此 PR 让部署者通过已有 Compose 配套配置明确选择 HTTP 登录。

在现有 `deploy/config.yaml` 的 `api` 段加入 `allow_insecure_http: true`，升级镜像并重新创建应用容器后，登录和退出的 Cookie 均不再带 `Secure`。省略或设为 `false` 保持原行为；`HttpOnly`、`SameSite=Lax` 和退出过期设置保留。不根据 `X-Forwarded-Proto` 自动降级，不影响上游 TLS 校验。同步更新配置模板、API 与部署文档。

HTTP 不加密，这是由部署者选择的显式开关。浏览器通过 HTTPS 访问时，即使反向代理通过 HTTP 连接容器，也应保留默认值。

本 PR 独立基于 `main`，不依赖自定义 Key 功能；只包含源码、测试和文档。

## English

On a plain HTTP deployment, password validation succeeds but the browser rejects the `Secure` session cookie, so subsequent requests remain unauthenticated. In v3.5.0 / `14e7967`, [admin/auth.rs](https://github.com/zyycn/codex-proxy-rs/blob/14e7967e1cd17eed36aa2a5b7d317fb32c8cde37/backend/crates/gateway-api/src/admin/auth.rs) hardcodes `Secure` for both login and logout. This PR adds an explicit deployment option in the existing Compose companion configuration.

Set `api.allow_insecure_http: true` in the existing `deploy/config.yaml`, upgrade the image, and recreate the application container to omit `Secure` from both cookies. Omitted/`false` preserves the current behavior. `HttpOnly`, `SameSite=Lax`, and logout expiration remain intact. Forwarded headers cannot downgrade the policy, and upstream TLS verification is unaffected. Configuration, deployment, and API documentation are updated together.

HTTP is unencrypted; this is an explicit operator choice. Keep the default when browsers use HTTPS, even if the reverse proxy connects to the container over HTTP.

This PR is independently based on `main` and does not depend on custom Keys. It contains only source, tests, and documentation.

## 验证 / Validation

- Rustfmt 与 `git diff --check` 通过。 / Rustfmt and `git diff --check` passed.
- `RUST_MIN_STACK=16777216 cargo clippy --release --manifest-path backend/Cargo.toml --all-targets --all-features --locked -- -D warnings`：通过。 / Passed.
- `cargo test --release --manifest-path backend/Cargo.toml -p gateway-api --test main --locked`：309 项通过，包含完整 Router 的默认/关闭/开启登录、状态和退出测试及转发头不降级检查。 / 309 passed, including full-router login/status/logout for omitted/false/true and forwarded-header behavior.
- `cargo test --release --manifest-path backend/Cargo.toml -p codex-proxy-rs --test main --locked`：37 项通过，包含配置加载和架构边界。 / 37 passed, including configuration loading and architecture checks.
- Compose 配置校验通过，使用独立的合成测试配置。 / Compose configuration validation passed with isolated synthetic configuration.
- `cargo build --release --manifest-path backend/Cargo.toml -p codex-proxy-rs --locked`：通过。 / Passed.
- Chromium `149.0.7827.55`，映射到回环地址的非 localhost 测试域名，真实 HTTP 服务及专用 PostgreSQL 18 / Redis 8：默认和省略开关时密码验证成功但 Cookie 不保存；开启时保持会话并可创建测试 Key；退出后 Cookie 和会话均清除。未模拟登录响应。 / Real HTTP service on a non-localhost test hostname mapped to loopback, with dedicated PostgreSQL 18 / Redis 8: omitted/false rejects cookie persistence despite successful password validation; true persists the session and permits creating a synthetic Key; logout clears the cookie and session. Login responses were not mocked.
